### PR TITLE
Ability to define aliases for column names

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -164,6 +164,7 @@ class Table extends RenderedObject
 
         $string = '<thead><tr>';
         foreach ($headers as $heading) {
+            $heading = $this->aliases && array_key_exists($heading, $this->aliases) ? $this->aliases[$heading] : $heading;
             $string .= "<th>{$heading}</th>";
         }
         $string .= '</tr></thead>';
@@ -213,10 +214,9 @@ class Table extends RenderedObject
             }
 
             if (!in_array($key, $headers)) {
-                $headers[] = $this->aliases && array_key_exists($key, $this->aliases) ? $this->aliases[$key] : $key;
+                $headers[] = $key;
             }
         }
-
         return $headers;
     }
 

--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -56,6 +56,11 @@ class Table extends RenderedObject
     protected $only = false;
 
     /**
+     * @var bool|array An array of aliases of columns. False if none.
+     */
+    protected $aliases = false;
+
+    /**
      * Renders the table
      *
      * @return string
@@ -208,7 +213,7 @@ class Table extends RenderedObject
             }
 
             if (!in_array($key, $headers)) {
-                $headers[] = $key;
+                $headers[] = $this->aliases && array_key_exists($key, $this->aliases) ? $this->aliases[$key] : $key;
             }
         }
 
@@ -276,6 +281,19 @@ class Table extends RenderedObject
     public function only(array $only)
     {
         $this->only = $only;
+
+        return $this;
+    }
+
+    /**
+     * Sets columns aliases
+     *
+     * @param array $only
+     * @return $this
+     */
+    public function alias(array $aliases)
+    {
+        $this->aliases = $aliases;
 
         return $this;
     }


### PR DESCRIPTION
hi
this will help for localization purposes :

``` php
Table::withContents(
    \App\Models\Product::all()->toArray()
)->alias([
    'name' =>trans('lables.name'), 
    'manufacturer' => trans('lables.manufacturer')
])
```
